### PR TITLE
Catch "wrong plan" error

### DIFF
--- a/src/lib/Helpers/ProvenExpertAPI.php
+++ b/src/lib/Helpers/ProvenExpertAPI.php
@@ -144,7 +144,14 @@ class ProvenExpertAPI {
 				$response_body = json_decode( wp_remote_retrieve_body( $request ), true );
 			}
 
-			set_transient( $cache_key, $response_body, 12 * HOUR_IN_SECONDS );
+			if ( 'error' !== $response_body['status'] ) {
+				set_transient( $cache_key, $response_body, 12 * HOUR_IN_SECONDS );
+			} else {
+				/* translators: %d: HTTP response code, %s: error message */
+				$error_message = sprintf( __( 'Error receiving the data from the ProvenExpert API (%1$d): %2$s', 'embeds-for-proven-expert' ), $response_code, implode( ', ', $response_body['errors'] ) );
+
+				return new WP_Error( 'efpe_request', $error_message, $response_body );
+			}
 		}
 
 		return $response_body;

--- a/src/lib/ProvenExpertEmbeds/AbstractProvenExpertEmbed.php
+++ b/src/lib/ProvenExpertEmbeds/AbstractProvenExpertEmbed.php
@@ -69,6 +69,16 @@ abstract class AbstractProvenExpertEmbed {
 		$response_body = ProvenExpertAPI::get_response_body( $this->api_endpoint, $request_args );
 
 		if ( is_wp_error( $response_body ) ) {
+			$error_data = $response_body->get_error_data();
+			if ( isset( $error_data['errors'] ) && in_array( 'wrong plan', $error_data['errors'] ) ) {
+				if ( current_user_can( 'edit_theme_options' ) ) {
+					return sprintf(
+						'<div style="border-left: 4px solid red; padding: 10px; background: #eee;">%s</div>',
+						esc_html__( 'Error (only visible to you): This widget cannot be viewed with your ProvenExpert plan!', 'embeds-for-proven-expert' )
+					);
+				}
+			}
+
 			return '';
 		}
 


### PR DESCRIPTION
When a widget is requested, the user does not have a paid plan for the response is having a 200 status code but the `html` in the response body is not available.